### PR TITLE
Don't format Floats as Strings

### DIFF
--- a/lib/puppet/catalog-diff/formater.rb
+++ b/lib/puppet/catalog-diff/formater.rb
@@ -9,7 +9,7 @@ module Puppet::CatalogDiff
     def format_simple(v, indent = '', do_indent = false, comma = '')
       str = ''
       str << indent if do_indent
-      v = "\"#{v}\"" unless [Integer, TrueClass, FalseClass].include?(v.class)
+      v = "\"#{v}\"" unless [Integer, Float, TrueClass, FalseClass].include?(v.class)
       str << v.to_s << comma << "\n"
     end
 


### PR DESCRIPTION
Previously if the only change in a class was a parameter's data type
from a `Float` to a `String`, then the class resource would be marked as
different, but [str_diff](https://github.com/camptocamp/puppet-catalog-diff/blob/b7f3031e380502eb6154242b1710b9ab7c105b42/lib/puppet/catalog-diff/comparer.rb#L130) would return `nil` causing a `Error: undefined method split' for nil:NilClass` error [here](https://github.com/camptocamp/puppet-catalog-diff/blob/b7f3031e380502eb6154242b1710b9ab7c105b42/lib/puppet/catalog-diff/comparer.rb#L60)

Fixes #32