### PR TITLE
comparer: exit early if checksum in old/new catalog is equal

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -146,11 +146,12 @@ module Puppet::CatalogDiff
         sum2 = Digest::MD5.hexdigest(str2)
       end
 
+      return nil if sum1 == sum2
+
       str1 = validate_encoding(str1)
       str2 = validate_encoding(str2)
 
       return nil unless str1 && str2
-      return nil if sum1 == sum2
 
       @@cached_str_diffs ||= {}
       @@cached_str_diffs["#{sum1}/#{sum2}"] ||= do_str_diff(str1, str2)


### PR DESCRIPTION
There is no benefit of calling `validate_encoding()` twice if the
checksums are equal. We can exit early.