### PR TITLE
comparer: exit earily if old/new contents are empty

### DIFF
--- a/lib/puppet/catalog-diff/comparer.rb
+++ b/lib/puppet/catalog-diff/comparer.rb
@@ -147,11 +147,10 @@ module Puppet::CatalogDiff
       end
 
       return nil if sum1 == sum2
+      return nil unless str1 && str2
 
       str1 = validate_encoding(str1)
       str2 = validate_encoding(str2)
-
-      return nil unless str1 && str2
 
       @@cached_str_diffs ||= {}
       @@cached_str_diffs["#{sum1}/#{sum2}"] ||= do_str_diff(str1, str2)


### PR DESCRIPTION
Previously we called `validate_encoding()` to force the old/new strings
to be UTF8. Afterwards we exit if one (or both) of the strings are
`nil`. If they are actuall `nil`, `validate_encoding()` will fail.
Hence it makes sense to move the return statement above the
`validate_encoding()` calls.