### PR TITLE
Add support for custom certificates to old PuppetDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ For node discovery and retrieving old catalogs, you can use
 `--old_puppetdb https://fqdn:8081`. To get new catalogs from a specific
 Puppetdb, use `--new_puppetdb https://fqdn:8081`.
 
+`puppet catalog diff` works with the TLS certificates that the agent also uses.
+You can see the related files by checking `puppet config print | grep ssl`. If
+the old PuppetDB uses certificates from a different CA, you can provide those
+via CLI options Those are:
+
+* `--old_puppetdb_tls_cert=`
+* `--old_puppetdb_tls_key=`
+* `--old_puppetdb_tls_ca=`
+
 ## Limitations
 
 This code only validates the catalogs, it cannot tell you if the behavior of

--- a/lib/puppet/catalog-diff/tlsfactory.rb
+++ b/lib/puppet/catalog-diff/tlsfactory.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Puppet::CatalogDiff
+module Puppet::CatalogDiff
+  # create a proper TLS context for the Puppet HTTP client
+  class Tlsfactory
+    def self.ssl_context(tls_cert, tls_key, tls_ca)
+      # Load certificates to make a connection to a possible foreign / not-by-default-trusted HTTPS resource
+      x509 = Puppet::X509::CertProvider.new
+      cacerts = x509.load_cacerts_from_pem(File.read(tls_ca, encoding: Encoding::UTF_8))
+      client_cert = x509.load_client_cert_from_pem(File.read(tls_cert, encoding: Encoding::UTF_8))
+      private_key = x509.load_private_key_from_pem(File.read(tls_key, encoding: Encoding::UTF_8))
+      prov = Puppet::SSL::SSLProvider.new
+      prov.create_context(revocation: false, cacerts: cacerts, private_key: private_key, client_cert: client_cert, include_system_store: true, crls: [])
+    end
+  end
+end

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -14,6 +14,9 @@ Puppet::Face.define(:catalog, '0.0.1') do
     summary 'Compare catalogs from different puppet versions.'
     arguments '<catalog1> <catalog2>'
     puppetdb_url = Puppet::Util::Puppetdb.config.server_urls[0]
+    hostcert = Puppet.settings[:hostcert]
+    hostprivkey = Puppet.settings[:hostprivkey]
+    localcacert = Puppet.settings[:localcacert]
 
     option '--fact_search=' do
       summary 'Fact search used to filter which catalogs are compiled and compared'
@@ -83,6 +86,21 @@ Puppet::Face.define(:catalog, '0.0.1') do
     option '--old_puppetdb=' do
       summary 'URI to PuppetDB to find nodes if --node_list is not set. Also used to download old catalogs. Defaults to first server in puppetdb.conf'
       default_to { puppetdb_url }
+    end
+
+    option '--old_puppetdb_tls_cert=' do
+      summary "Optional absolute path to a client certificate to authenticate against the old PuppetDB. If not provided, the Puppet Agent default certificate will be used. Defaults to #{hostcert}."
+      default_to { hostcert }
+    end
+
+    option '--old_puppetdb_tls_key=' do
+      summary "Optional absolute path to a TLS private key in pem format. If not provided, the Puppet Agent default key will be used. Defaults to #{hostprivkey}."
+      default_to { hostprivkey }
+    end
+
+    option '--old_puppetdb_tls_ca=' do
+      summary "Optional absolute path to a CA pem file. If not provided, the Puppet Agent CA will be used. Defaults to #{localcacert}."
+      default_to { localcacert }
     end
 
     option '--new_puppetdb=' do
@@ -186,6 +204,9 @@ Puppet::Face.define(:catalog, '0.0.1') do
           old_catalog_from_puppetdb: options[:old_catalog_from_puppetdb],
           new_catalog_from_puppetdb: options[:new_catalog_from_puppetdb],
           old_puppetdb: options[:old_puppetdb],
+          old_puppetdb_tls_cert: options[:old_puppetdb_tls_cert],
+          old_puppetdb_tls_key: options[:old_puppetdb_tls_key],
+          old_puppetdb_tls_ca: options[:old_puppetdb_tls_ca],
           new_puppetdb: options[:new_puppetdb],
           node_list: options[:node_list]
         )

--- a/lib/puppet/face/catalog/seed.rb
+++ b/lib/puppet/face/catalog/seed.rb
@@ -6,6 +6,9 @@ Puppet::Face.define(:catalog, '0.0.1') do
     summary 'Generate a series of catalogs'
     arguments '<path/to/seed/directory> fact=CaseSensitiveValue'
     puppetdb_url = Puppet::Util::Puppetdb.config.server_urls[0]
+    hostcert = Puppet.settings[:hostcert]
+    hostprivkey = Puppet.settings[:hostprivkey]
+    localcacert = Puppet.settings[:localcacert]
 
     option '--master_server SERVER' do
       summary 'The server from which to download the catalogs from'
@@ -23,6 +26,21 @@ Puppet::Face.define(:catalog, '0.0.1') do
     option '--puppetdb=' do
       summary "URI to the PuppetDB, defaults to #{puppetdb_url}"
       default_to { puppetdb_url }
+    end
+
+    option '--puppetdb_tls_cert=' do
+      summary "Optional absolute path to a client certificate to authenticate against the old PuppetDB. If not provided, the Puppet Agent default certificate will be used. Defaults to #{hostcert}."
+      default_to { hostcert }
+    end
+
+    option '--puppetdb_tls_key=' do
+      summary "Optional absolute path to a TLS private key in pem format. If not provided, the Puppet Agent default key will be used. Defaults to #{hostprivkey}."
+      default_to { hostprivkey }
+    end
+
+    option '--puppetdb_tls_ca=' do
+      summary "Optional absolute path to a CA pem file. If not provided, the Puppet Agent CA will be used. Defaults to #{localcacert}."
+      default_to { localcacert }
     end
 
     description <<-'EOT'
@@ -70,7 +88,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
                 options[:master_server],
                 options[:certless],
                 options[:catalog_from_puppetdb],
-                options[:puppetdb]
+                options[:puppetdb],
+                options[:puppetdb_tls_cert],
+                options[:puppetdb_tls_key],
+                options[:puppetdb_tls_ca]
               )
               mutex.synchronize { compiled_nodes << node_name }
             rescue Exception => e


### PR DESCRIPTION
This implementation is based on a suggestion from Josh Cooper:
```
Yeah can use
https://www.rubydoc.info/gems/puppet/Puppet/X509/CertProvider to load
x509 certificates and then create a custom ssl context using
https://www.rubydoc.info/gems/puppet/Puppet/SSL/SSLProvider, and pass it
into any of the http client methods, e.g.
x509 = Puppet::X509::CertProvider.new
cacerts = x509.load_cacerts_from_pem(File.read('...', encoding: Encoding::UTF_8))
prov = Puppet::SSL::Provider.new
ctx = prov.create_context(cacerts: cacerts, revocation: false, ...)
response = Puppet.runtime[:http].get(URI('https://...', options: { ssl_context: ctx })
```

Slack link:
https://puppetcommunity.slack.com/archives/C0W1X7ZAL/p1652464163822119?thread_ts=1652453262.819079&cid=C0W1X7ZAL


depends on https://github.com/voxpupuli/puppet-catalog-diff/pull/68